### PR TITLE
fix(packetError): fix packet error for ItemFrame.

### DIFF
--- a/src/main/java/com/github/sachin/lootin/listeners/EntityMetaDataPacketListener.java
+++ b/src/main/java/com/github/sachin/lootin/listeners/EntityMetaDataPacketListener.java
@@ -17,6 +17,7 @@ import com.github.sachin.lootin.Lootin;
 import com.github.sachin.lootin.utils.LConstants;
 
 import com.github.sachin.prilib.Prilib;
+import com.github.sachin.prilib.McVersion;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
@@ -58,7 +59,7 @@ public class EntityMetaDataPacketListener extends PacketAdapter{
             }
             List<WrappedWatchableObject> objects = packet.getWatchableCollectionModifier().readSafely(0);
             for(WrappedWatchableObject object : objects){
-                if(object.getIndex()==8){
+                if(object.getIndex()==9){
                     if(entity.getPersistentDataContainer().has(key,PersistentDataType.INTEGER)){
                         object.setValue(new ItemStack(Material.AIR));
                     }


### PR DESCRIPTION
Fixes #49 , the packet index for DisplayedItem has changed since 1.21.6. You should add a version check with McVersion but I didn't find a way to do it, I really tried, I promise.

Tested on Paper 1.21.7 with latest ProtocolLib version.